### PR TITLE
chore: default buffer_binding constructor

### DIFF
--- a/src/webgpu/buffer_binding.cpp
+++ b/src/webgpu/buffer_binding.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<WGPUBindGroup> make_binding(WGPUBindGroup bg) {
 
 namespace ligero::webgpu {
 
-buffer_binding::buffer_binding() { }
+buffer_binding::buffer_binding() = default;
 
 buffer_binding::buffer_binding(buffer_binding::bindgroup_type bg)
     : buffer_binding(bg, {}) { }


### PR DESCRIPTION
Replaces an empty constructor body with = default for clarity and consistency